### PR TITLE
fix: correcao da dependencia do deploy para producao

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
         run: dotnet test ./Review-Filmes.Test.EndToEnd/Review-Filmes.Test.EndToEnd.csproj
       
   deploy-producao:
-      needs: [deploy-homologacao]
+      needs: [teste-e2e]
       uses: diego64/desafio-cicd/.github/workflows/deploy.yml@main
       secrets: inherit
       with:


### PR DESCRIPTION
@diego64 o needs da action deploy-producao estava apontando para a dependencia de homologação pulando a parte do teste E2E